### PR TITLE
fix(vllm): auto-dispatch when tracing without dispatch=True

### DIFF
--- a/src/nnsight/modeling/vllm/vllm.py
+++ b/src/nnsight/modeling/vllm/vllm.py
@@ -18,6 +18,7 @@ from vllm.engine.arg_utils import EngineArgs
 from vllm.entrypoints.llm import LLM
 
 from ...intervention.envoy import Envoy
+from ...intervention.tracing.tracer import ScanningTracer
 from ...intervention.tracing.util import push_variables
 from ...util import WrapperModule
 from ..mixins import RemoteableMixin
@@ -248,6 +249,9 @@ class VLLM(RemoteableMixin):
         push_variables(self._interleaver.mediators[0].info.frame, saves)
 
     def interleave(self, fn: Callable, *args, **kwargs):
+        """Execute the traced function with vLLM, dispatching the engine if needed."""
+        if not self.dispatched and not isinstance(self._interleaver.tracer, ScanningTracer):
+            self.dispatch()
 
         try:
             fn(*args, **kwargs)

--- a/tests/test_vllm_dispatch_bug.py
+++ b/tests/test_vllm_dispatch_bug.py
@@ -1,0 +1,32 @@
+"""Test for VLLM dispatch=False tracing bug."""
+import pytest
+import torch
+
+try:
+    from nnsight.modeling.vllm import VLLM
+except Exception as e:
+    pytest.skip(f"Skipping VLLM tests: \n{e}", allow_module_level=True)
+
+
+@pytest.fixture(scope="module")
+def vllm_gpt2_no_dispatch():
+    """VLLM model initialized without dispatch=True."""
+    return VLLM("gpt2", tensor_parallel_size=1, gpu_memory_utilization=0.1)
+
+
+@torch.no_grad()
+def test_trace_without_dispatch(vllm_gpt2_no_dispatch):
+    """Tracing should work even when dispatch=False at init time."""
+    model = vllm_gpt2_no_dispatch
+
+    assert not model.dispatched, "Model should not be dispatched initially"
+    assert model.vllm_entrypoint is None, "vllm_entrypoint should be None initially"
+
+    with model.trace("The Eiffel Tower is located in the city of", temperature=0.0, top_p=1):
+        logits = model.logits.output.save()
+
+    assert model.dispatched, "Model should be dispatched after trace"
+    assert model.vllm_entrypoint is not None, "vllm_entrypoint should exist after trace"
+
+    next_token = model.tokenizer.decode(logits.argmax(dim=-1))
+    assert next_token == " Paris"


### PR DESCRIPTION
## Summary

- Fixed bug where `VLLM.trace()` fails when model initialized without `dispatch=True`
- `VLLM.interleave()` was overriding `MetaMixin.interleave()` without the dispatch logic
- Added automatic dispatch check so tracing works regardless of init-time dispatch setting

## Problem

```python
# This was failing
model = VLLM("gpt2", gpu_memory_utilization=0.1)  # dispatch=False by default
with model.trace("Hello world") as tracer:
    logits = model.logits.output.save()  # AttributeError: vllm_entrypoint is None
```

## Solution

Added the dispatch check from `MetaMixin.interleave()` to `VLLM.interleave()`:

```python
if not self.dispatched and not isinstance(self._interleaver.tracer, ScanningTracer):
    self.dispatch()
```

## Test plan

- [x] New test `test_trace_without_dispatch` verifies the fix
- [x] All existing VLLM tests pass (11/13, 1 skipped, 1 pre-existing failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures tracing works when `VLLM` is initialized without `dispatch=True` by auto-dispatching before execution.
> 
> - Updates `VLLM.interleave()` to call `dispatch()` when `not self.dispatched` and tracer is not `ScanningTracer`
> - Adds regression test `tests/test_vllm_dispatch_bug.py` validating trace without init-time dispatch and expected next token decoding
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d96d07dc11c690c474a0c92d11804a084efaa63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->